### PR TITLE
Fix `gameRev` check.

### DIFF
--- a/Gen 3/mGBA/FRLG_RNG_mGBA.lua
+++ b/Gen 3/mGBA/FRLG_RNG_mGBA.lua
@@ -321,7 +321,7 @@ local wrongGameVersion
 function setGameVersion()
  local gameVersionCode = emu:read8(0x80000AE)
  local gameLanguageCode = emu:read8(0x80000AF)
- local gameRev = emu:read8(0x80000BD) == 0x62
+ local gameRev = emu:read8(0x80000BC) == 1
 
  if gameVersionCode == 0x45 then  -- Check game version
   gameVersion = "Emerald"


### PR DESCRIPTION
This pull request will fix #2.

It does so by checking the software version number rather than the complement check in the GBA cartridge header.

https://problemkaputt.de/gbatek-gba-cartridge-header.htm